### PR TITLE
Parameterize permissions for client's mount point

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ nfs_mode: client
 #   - server: my.host
 #     export_dir: /exported/path
 #     mount_point: /mnt
+#     owner: root
+#     group: root
+#     mode: '0755'
 #   - server: other.host
 nfs_mounts: []
 
@@ -30,6 +33,9 @@ nfs_default_export_dir: /tmp                         # [SC] Directory exported b
 nfs_default_export_opts: ro,sync,root_squash         # [S]  Export options on server
 nfs_default_export_user: root                        # [S]  Export as user
 nfs_default_export_group: root                       # [S]  Export as group
-nfs_default_export_mode: u=rwX,g=rX,o=                   # [S]  Export permissions
+nfs_default_export_mode: u=rwX,g=rX,o=               # [S]  Export permissions
 nfs_default_mount_point: /mnt                        # [C]  Mount point on client
 nfs_default_mount_opts: ro,bg,soft,intr,proto=tcp    # [C]  Mount options on client
+nfs_default_mount_owner: root                        # [C]  Owner of mount point on client
+nfs_default_mount_group: root                        # [C]  Group of mount point on client
+nfs_default_mount_mode: '0755'                       # [C]  Mode of mount point on client

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -4,7 +4,7 @@
   when: nfs_mount.version | default(nfs_default_version) == 3
 
 - name: Make sure mount point is present
-  file: path={{nfs_mount.mount_point | default(nfs_default_mount_point)}} state=directory owner=root group=root mode=0755
+  file: path={{nfs_mount.mount_point | default(nfs_default_mount_point)}} state=directory owner={{nfs_mount.owner | default(nfs_default_mount_owner)}}  group={{nfs_mount.group | default(nfs_default_mount_group)}} mode={{nfs_mount.mode | default(nfs_default_mount_mode)}}
 
 - name: Mount exported filesystem
   mount: name={{nfs_mount.mount_point | default(nfs_default_mount_point)}} src={{nfs_mount.server | default(nfs_default_server)}}:{{nfs_mount.export_dir | default(nfs_default_export_dir)}} fstype=nfs opts={{nfs_mount.mount_opts | default(nfs_default_mount_opts)}},vers={{nfs_mount.version | default(nfs_default_version)}} state=mounted


### PR DESCRIPTION
Support different permission models for the nfs mount points on clients.